### PR TITLE
Fix duplecate error

### DIFF
--- a/lib/kakine.rb
+++ b/lib/kakine.rb
@@ -6,6 +6,7 @@ require 'kakine/resource'
 require 'kakine/hash_sort'
 require 'kakine/security_group'
 require 'kakine/diff_parser'
+require 'kakine/validate'
 
 module Kakine
 end

--- a/lib/kakine/cli.rb
+++ b/lib/kakine/cli.rb
@@ -30,11 +30,10 @@ module Kakine
 
       security_groups = []
       delay_create = []
-
       diffs = HashDiff.diff(
         Kakine::Resource.security_groups_hash(options[:tenant]),
         Kakine::Resource.yaml(filename)
-      )
+      ).sort.reverse
 
       diffs.each do |diff|
         security_groups <<  Kakine::SecurityGroup.new(options[:tenant], diff)

--- a/lib/kakine/cli.rb
+++ b/lib/kakine/cli.rb
@@ -43,8 +43,8 @@ module Kakine
         security_groups <<  Kakine::SecurityGroup.new(options[:tenant], diff)
       end
 
-      begin
-        security_groups.each do |sg|
+      security_groups.each do |sg|
+        begin
           if sg.update_rule? # foo[2]
             case
             when sg.add?
@@ -74,14 +74,13 @@ module Kakine
               raise
             end
           end
+        rescue Excon::Errors::Conflict => e
+          JSON.parse(e.response[:body]).each { |e,m| puts "#{e}:#{m["message"]}" }
         end
-        # update rule delay create
-        delay_create.each do |sg|
-          operation.create_security_rule(sg)
-        end
-
-      rescue Excon::Errors::Conflict => e
-        JSON.parse(e.response[:body]).each { |e,m| puts "#{e}:#{m["message"]}" }
+      end
+      # update rule delay create
+      delay_create.each do |sg|
+        operation.create_security_rule(sg)
       end
     end
   end

--- a/lib/kakine/cli/operation.rb
+++ b/lib/kakine/cli/operation.rb
@@ -39,6 +39,7 @@ module Kakine
           @adapter.delete_rule(security_group_rule.id)
         end if sg.has_rules?
       end
+
     end
   end
 end

--- a/lib/kakine/diff_parser.rb
+++ b/lib/kakine/diff_parser.rb
@@ -17,17 +17,15 @@ module Kakine
             raise "description is not exists"
           end
         else
-          regex_update_description = /^[\w-]+\.description$/
-          regex_update_rules       = /^[\w-]+\.rules$/
-          regex_update_attr        = /^[\w-]+.[\w]+\[(\d)\].([\w]+)$/
 
-          if parse_target_object_name.match(regex_update_description)
+          if parse_target_object_name.match(update_description_matcher)
             rules = registered_sg[parse_security_group_name]["rules"]
             description = parse_after_description
-          elsif  parse_target_object_name.match(regex_update_rules)
+          elsif  parse_target_object_name.match(update_rules_matcher)
+            prev_rules = registered_sg[parse_security_group_name]["rules"]
             rules = parse_after_rules
             description = registered_sg[parse_security_group_name]["description"]
-          elsif m = parse_target_object_name.match(regex_update_attr)
+          elsif m = parse_target_object_name.match(update_attr_matcher)
             rules = [registered_sg[parse_security_group_name]["rules"][m[1].to_i]]
             prev_rules = Marshal.load(Marshal.dump(rules)) # backup before value
             rules[0][m[2]] = parse_after_attr
@@ -82,6 +80,18 @@ module Kakine
 
       def unit_is_description?
         parse_target_object_name.index('description')
+      end
+
+      def update_description_matcher
+        /^[\w-]+\.description$/
+      end
+
+      def update_rules_matcher
+        /^[\w-]+\.rules$/
+      end
+
+      def update_attr_matcher
+        /^[\w-]+.[\w]+\[(\d)\].([\w]+)$/
       end
     end
   end

--- a/lib/kakine/diff_parser.rb
+++ b/lib/kakine/diff_parser.rb
@@ -71,7 +71,7 @@ module Kakine
       alias :parse_after_rules       :parse_after_attr
 
       def unit_is_security_group?
-        parse_security_group && parse_security_group["rules"]
+        parse_security_group && parse_security_group.key?("rules")
       end
 
       def unit_is_security_rule?

--- a/lib/kakine/hash_sort.rb
+++ b/lib/kakine/hash_sort.rb
@@ -6,7 +6,7 @@ class Hash
           ascii += v.ord.to_i unless v.nil?
           ascii
         end
-      end unless sg[1].nil? || sg[1]['rules'].nil?
+      end if !sg[1].nil? && !sg[1]['rules'].nil?
     end
     Hash[self]
   end

--- a/lib/kakine/resource.rb
+++ b/lib/kakine/resource.rb
@@ -24,10 +24,10 @@ module Kakine
           sg.protocol == attributes["protocol"] &&
           sg.port_range_max == attributes["port_range_max"] &&
           sg.port_range_min == attributes["port_range_min"] &&
+          sg.ethertype == attributes["ethertype"] &&
           (
             (
-              sg.remote_ip_prefix == attributes["remote_ip"] &&
-              sg.ethertype == attributes["ethertype"]
+              sg.remote_ip_prefix == attributes["remote_ip"]
             ) ||
             (
               sg.remote_group_id == attributes["remote_group_id"] &&
@@ -58,6 +58,7 @@ module Kakine
           rule_hash = {}
           rule_hash["direction"] = rule.direction
           rule_hash["protocol"] = rule.protocol
+          rule_hash["ethertype"] = rule.ethertype
 
           if rule.port_range_max == rule.port_range_min
             rule_hash["port"] = rule.port_range_max
@@ -71,7 +72,6 @@ module Kakine
             rule_hash["remote_group"] = response.data[:body]["security_group"]["name"]
           else
             rule_hash["remote_ip"] = rule.remote_ip_prefix
-            rule_hash["ethertype"] = rule.ethertype
           end
           rules << rule_hash
         end

--- a/lib/kakine/resource.rb
+++ b/lib/kakine/resource.rb
@@ -31,7 +31,7 @@ module Kakine
               sg.remote_ip_prefix == attributes["remote_ip"]
             ) ||
             (
-              !attributes.key?("remote_group_id") &&
+              attributes.key?("remote_group_id") &&
               sg.remote_group_id == attributes["remote_group_id"]
             )
           )

--- a/lib/kakine/resource.rb
+++ b/lib/kakine/resource.rb
@@ -3,7 +3,7 @@ module Kakine
   class Resource
     class << self
       def yaml(filename)
-        YAML.load_file(filename).to_hash.sg_rules_sort
+        Hash[YAML.load_file(filename).to_hash.sort].sg_rules_sort
       end
 
       def tenant(tenant_name)
@@ -48,7 +48,7 @@ module Kakine
           sg_hash[sg.name]["rules"]       = format_security_group(sg)
           sg_hash[sg.name]["description"] = sg.description
         end
-        sg_hash.sg_rules_sort
+        Hash[sg_hash.sort].sg_rules_sort
       end
 
       def format_security_group(security_group)
@@ -58,7 +58,6 @@ module Kakine
           rule_hash = {}
           rule_hash["direction"] = rule.direction
           rule_hash["protocol"] = rule.protocol
-          rule_hash["ethertype"] = rule.ethertype
 
           if rule.port_range_max == rule.port_range_min
             rule_hash["port"] = rule.port_range_max
@@ -73,6 +72,7 @@ module Kakine
           else
             rule_hash["remote_ip"] = rule.remote_ip_prefix
           end
+          rule_hash["ethertype"] = rule.ethertype
           rules << rule_hash
         end
         rules

--- a/lib/kakine/resource.rb
+++ b/lib/kakine/resource.rb
@@ -27,11 +27,11 @@ module Kakine
           sg.ethertype == attributes["ethertype"] &&
           (
             (
-              !attributes["remote_ip"].nil? &&
+              attributes.key?("remote_ip") &&
               sg.remote_ip_prefix == attributes["remote_ip"]
             ) ||
             (
-              !attributes["remote_group_id"].nil? &&
+              !attributes.key?("remote_group_id") &&
               sg.remote_group_id == attributes["remote_group_id"]
             )
           )

--- a/lib/kakine/resource.rb
+++ b/lib/kakine/resource.rb
@@ -27,11 +27,12 @@ module Kakine
           sg.ethertype == attributes["ethertype"] &&
           (
             (
+              !attributes["remote_ip"].nil? &&
               sg.remote_ip_prefix == attributes["remote_ip"]
             ) ||
             (
-              sg.remote_group_id == attributes["remote_group_id"] &&
-              !attributes["remote_group_id"].nil?
+              !attributes["remote_group_id"].nil? &&
+              sg.remote_group_id == attributes["remote_group_id"]
             )
           )
         end
@@ -77,6 +78,7 @@ module Kakine
         end
         rules
       end
+
     end
   end
 end

--- a/lib/kakine/security_group.rb
+++ b/lib/kakine/security_group.rb
@@ -29,7 +29,11 @@ module Kakine
     end
 
     def update_attr?
-      @transaction_type == "~"
+      @transaction_type == "~" && !@rules.empty?
+    end
+
+    def delete_all_rules?
+      @transaction_type == "~" && @rules.empty? 
     end
 
     def update_rule?

--- a/lib/kakine/validate.rb
+++ b/lib/kakine/validate.rb
@@ -1,0 +1,48 @@
+module Kakine
+  class Validate
+    class << self
+      def validate_file_input(load_sg)
+        err = []
+        load_sg.each do |sg|
+          err << validate_attributes(sg)
+          err << validate_rules(sg)
+        end
+        if err.detect {|e| !e.nil? }
+          err.map { |m| puts m unless m.nil? }
+          false
+        else
+          true
+        end
+      end
+
+      def validate_attributes(sg)
+        case
+        when sg[1].nil?
+          "[error] #{sg[0]}:rules and description is required"
+        when !sg[1].key?("rules")
+          "[error] #{sg[0]}:rules is required"
+        when !sg[1].key?("description")
+          "[error] #{sg[0]}:description is required"
+        end
+      end
+
+      def validate_rules(sg)
+        sg[1]["rules"].each do |rule|
+          case
+          when !rule.key?("port") && (!rule.key?("port_range_max") || !rule.key?("port_range_min"))
+            return "[error] #{sg[0]}:rules port is required"
+          when !rule.key?("remote_ip") && !rule.key?("remote_group_id")
+            return "[error] #{sg[0]}:rules remote_ip or remote_group_id required"
+          else
+            %w(direction protocol ethertype).each do |k|
+              if !rule.key?(k)
+                return "[error] #{sg[0]}:rules #{k} is required"
+              end
+            end
+          end
+        end unless sg[1]["rules"].nil?
+        nil
+      end
+    end
+  end
+end

--- a/lib/kakine/validate.rb
+++ b/lib/kakine/validate.rb
@@ -31,8 +31,8 @@ module Kakine
           case
           when !rule.key?("port") && (!rule.key?("port_range_max") || !rule.key?("port_range_min"))
             return "[error] #{sg[0]}:rules port is required"
-          when !rule.key?("remote_ip") && !rule.key?("remote_group_id")
-            return "[error] #{sg[0]}:rules remote_ip or remote_group_id required"
+          when !rule.key?("remote_ip") && !rule.key?("remote_group")
+            return "[error] #{sg[0]}:rules remote_ip or remote_group required"
           else
             %w(direction protocol ethertype).each do |k|
               if !rule.key?(k)

--- a/lib/kakine/version.rb
+++ b/lib/kakine/version.rb
@@ -1,3 +1,3 @@
 module Kakine
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/test/fixtures/cli/actual.yaml
+++ b/test/fixtures/cli/actual.yaml
@@ -4,10 +4,12 @@ bob-b:
     protocol: tcp
     port: 443
     remote_ip: 0.0.0.0/0
+    ethertype: IPv4
   - direction: ingress
     protocol: tcp
     port: 80
     remote_ip: 0.0.0.0/0
+    ethertype: IPv4
   description: bob-b
 bob-c:
   rules:
@@ -15,4 +17,5 @@ bob-c:
     protocol: tcp
     port: 443
     remote_ip: 0.0.0.0/0
+    ethertype: IPv4
   description: bob-c

--- a/test/fixtures/cli/actual.yaml
+++ b/test/fixtures/cli/actual.yaml
@@ -19,3 +19,11 @@ bob-c:
     remote_ip: 0.0.0.0/0
     ethertype: IPv4
   description: bob-c
+bob-g:
+  rules:
+  - direction: ingress
+    protocol: tcp
+    port: 161
+    remote_group: bob-b
+    ethertype: IPv4
+  description: bob-g

--- a/test/fixtures/cli/expected001.yaml
+++ b/test/fixtures/cli/expected001.yaml
@@ -4,10 +4,12 @@ bob-b:
     protocol: tcp
     port: 443
     remote_ip: 0.0.0.0/0
+    ethertype: IPv4
   - direction: ingress
     protocol: tcp
     port: 80
     remote_ip: 0.0.0.0/0
+    ethertype: IPv4
   description: bob-b
 bob-c:
   rules:
@@ -15,5 +17,6 @@ bob-c:
     protocol: tcp
     port: 443
     remote_ip: 0.0.0.0/0
+    ethertype: IPv4
   description: bob-c
 bob-a:

--- a/test/fixtures/cli/expected001.yaml
+++ b/test/fixtures/cli/expected001.yaml
@@ -20,3 +20,5 @@ bob-c:
     ethertype: IPv4
   description: bob-c
 bob-a:
+  rules:
+  description: bob-a

--- a/test/fixtures/cli/expected001.yaml
+++ b/test/fixtures/cli/expected001.yaml
@@ -19,6 +19,14 @@ bob-c:
     remote_ip: 0.0.0.0/0
     ethertype: IPv4
   description: bob-c
+bob-g:
+  rules:
+  - direction: ingress
+    protocol: tcp
+    port: 161
+    remote_group: bob-b
+    ethertype: IPv4
+  description: bob-g
 bob-a:
   rules:
   description: bob-a

--- a/test/fixtures/cli/expected002.yaml
+++ b/test/fixtures/cli/expected002.yaml
@@ -19,6 +19,14 @@ bob-c:
     remote_ip: 0.0.0.0/0
     ethertype: IPv4
   description: bob-c
+bob-g:
+  rules:
+  - direction: ingress
+    protocol: tcp
+    port: 161
+    remote_group: bob-b
+    ethertype: IPv4
+  description: bob-g
 bob-a:
   rules:
   - direction: ingress
@@ -32,3 +40,11 @@ bob-a:
     remote_ip: 0.0.0.0/0
     ethertype: IPv4
   description: bob-a
+bob-e:
+  rules:
+  - direction: ingress
+    protocol: tcp
+    port: 162
+    remote_group: bob-g
+    ethertype: IPv4
+  description: bob-e

--- a/test/fixtures/cli/expected004.yaml
+++ b/test/fixtures/cli/expected004.yaml
@@ -4,14 +4,17 @@ bob-b:
     protocol: tcp
     port: 443
     remote_ip: 0.0.0.0/0
+    ethertype: IPv4
   - direction: ingress
     protocol: tcp
     port: 80
     remote_ip: 0.0.0.0/0
+    ethertype: IPv4
   - direction: ingress
     protocol: tcp
     port: 3000
     remote_ip: 0.0.0.0/0
+    ethertype: IPv4
   description: bob-b
 bob-c:
   rules:
@@ -19,4 +22,5 @@ bob-c:
     protocol: tcp
     port: 443
     remote_ip: 0.0.0.0/0
+    ethertype: IPv4
   description: bob-c

--- a/test/fixtures/cli/expected004.yaml
+++ b/test/fixtures/cli/expected004.yaml
@@ -24,3 +24,16 @@ bob-c:
     remote_ip: 0.0.0.0/0
     ethertype: IPv4
   description: bob-c
+bob-g:
+  rules:
+  - direction: ingress
+    protocol: tcp
+    port: 161
+    remote_group: bob-b
+    ethertype: IPv4
+  - direction: ingress
+    protocol: tcp
+    port: 162
+    remote_group: bob-c
+    ethertype: IPv4
+  description: bob-g

--- a/test/fixtures/cli/expected005.yaml
+++ b/test/fixtures/cli/expected005.yaml
@@ -14,3 +14,6 @@ bob-c:
     remote_ip: 0.0.0.0/0
     ethertype: IPv4
   description: bob-c
+bob-g:
+  rules:
+  description: bob-g

--- a/test/fixtures/cli/expected005.yaml
+++ b/test/fixtures/cli/expected005.yaml
@@ -4,6 +4,7 @@ bob-b:
     protocol: tcp
     port: 443
     remote_ip: 0.0.0.0/0
+    ethertype: IPv4
   description: bob-b
 bob-c:
   rules:
@@ -11,4 +12,5 @@ bob-c:
     protocol: tcp
     port: 443
     remote_ip: 0.0.0.0/0
+    ethertype: IPv4
   description: bob-c

--- a/test/fixtures/cli/expected006.yaml
+++ b/test/fixtures/cli/expected006.yaml
@@ -19,3 +19,11 @@ bob-c:
     remote_ip: 0.0.0.0/0
     ethertype: IPv4
   description: bob-c
+bob-g:
+  rules:
+  - direction: ingress
+    protocol: tcp
+    port: 162
+    remote_group: bob-b
+    ethertype: IPv4
+  description: bob-g

--- a/test/fixtures/cli/expected006.yaml
+++ b/test/fixtures/cli/expected006.yaml
@@ -4,10 +4,12 @@ bob-b:
     protocol: tcp
     port: 443
     remote_ip: 0.0.0.0/0
+    ethertype: IPv4
   - direction: ingress
     protocol: tcp
     port: 3000
     remote_ip: 0.0.0.0/0
+    ethertype: IPv4
   description: bob-b
 bob-c:
   rules:
@@ -15,4 +17,5 @@ bob-c:
     protocol: tcp
     port: 443
     remote_ip: 0.0.0.0/0
+    ethertype: IPv4
   description: bob-c

--- a/test/fixtures/cli/expected007.yaml
+++ b/test/fixtures/cli/expected007.yaml
@@ -4,10 +4,12 @@ bob-b:
     protocol: tcp
     port: 443
     remote_ip: 0.0.0.0/0
+    ethertype: IPv4
   - direction: ingress
     protocol: tcp
     port: 80
     remote_ip: 0.0.0.0/0
+    ethertype: IPv4
   description: bob-b
 bob-c:
   rules:
@@ -15,4 +17,5 @@ bob-c:
     protocol: tcp
     port: 443
     remote_ip: 0.0.0.0/0
+    ethertype: IPv4
   description: bob-d

--- a/test/fixtures/cli/expected007.yaml
+++ b/test/fixtures/cli/expected007.yaml
@@ -19,3 +19,11 @@ bob-c:
     remote_ip: 0.0.0.0/0
     ethertype: IPv4
   description: bob-d
+bob-g:
+  rules:
+  - direction: ingress
+    protocol: tcp
+    port: 161
+    remote_group: bob-b
+    ethertype: IPv4
+  description: bob-g

--- a/test/fixtures/cli/expected008.yaml
+++ b/test/fixtures/cli/expected008.yaml
@@ -2,12 +2,12 @@ bob-b:
   rules:
   - direction: ingress
     protocol: tcp
-    port: 443
+    port: 80
     remote_ip: 0.0.0.0/0
     ethertype: IPv4
   - direction: ingress
     protocol: tcp
-    port: 80
+    port: 443
     remote_ip: 0.0.0.0/0
     ethertype: IPv4
   description: bob-b
@@ -19,16 +19,3 @@ bob-c:
     remote_ip: 0.0.0.0/0
     ethertype: IPv4
   description: bob-c
-bob-a:
-  rules:
-  - direction: ingress
-    protocol: tcp
-    port: 80
-    remote_ip: 0.0.0.0/0
-    ethertype: IPv4
-  - direction: ingress
-    protocol: tcp
-    port: 443
-    remote_ip: 0.0.0.0/0
-    ethertype: IPv4
-  description: bob-a

--- a/test/fixtures/cli/expected008.yaml
+++ b/test/fixtures/cli/expected008.yaml
@@ -19,3 +19,11 @@ bob-c:
     remote_ip: 0.0.0.0/0
     ethertype: IPv4
   description: bob-c
+bob-g:
+  rules:
+  - direction: ingress
+    protocol: tcp
+    port: 161
+    remote_group: bob-b
+    ethertype: IPv4
+  description: bob-g

--- a/test/fixtures/cli/expected009.yaml
+++ b/test/fixtures/cli/expected009.yaml
@@ -9,3 +9,11 @@ bob-c:
     remote_ip: 0.0.0.0/0
     ethertype: IPv4
   description: bob-c
+bob-g:
+  rules:
+  - direction: ingress
+    protocol: tcp
+    port: 161
+    remote_group: bob-b
+    ethertype: IPv4
+  description: bob-g

--- a/test/fixtures/cli/expected009.yaml
+++ b/test/fixtures/cli/expected009.yaml
@@ -11,3 +11,4 @@ bob-b:
     remote_ip: 0.0.0.0/0
     ethertype: IPv4
   description: bob-b
+bob-c:

--- a/test/fixtures/cli/expected009.yaml
+++ b/test/fixtures/cli/expected009.yaml
@@ -1,14 +1,11 @@
 bob-b:
   rules:
+  description: bob-b
+bob-c:
+  rules:
   - direction: ingress
     protocol: tcp
     port: 443
     remote_ip: 0.0.0.0/0
     ethertype: IPv4
-  - direction: ingress
-    protocol: tcp
-    port: 80
-    remote_ip: 0.0.0.0/0
-    ethertype: IPv4
-  description: bob-b
-bob-c:
+  description: bob-c

--- a/test/fixtures/cli/expected010.yaml
+++ b/test/fixtures/cli/expected010.yaml
@@ -13,3 +13,11 @@ bob-b:
   description: bob-b
 bob-c:
   description: bob-c
+bob-g:
+  rules:
+  - direction: ingress
+    protocol: tcp
+    port: 161
+    remote_group: bob-b
+    ethertype: IPv4
+  description: bob-g

--- a/test/fixtures/cli/expected010.yaml
+++ b/test/fixtures/cli/expected010.yaml
@@ -1,0 +1,15 @@
+bob-b:
+  rules:
+  - direction: ingress
+    protocol: tcp
+    port: 443
+    remote_ip: 0.0.0.0/0
+    ethertype: IPv4
+  - direction: ingress
+    protocol: tcp
+    port: 80
+    remote_ip: 0.0.0.0/0
+    ethertype: IPv4
+  description: bob-b
+bob-c:
+  description: bob-c

--- a/test/fixtures/cli/expected011.yaml
+++ b/test/fixtures/cli/expected011.yaml
@@ -18,3 +18,11 @@ bob-c:
     port: 443
     remote_ip: 0.0.0.0/0
     ethertype: IPv4
+bob-g:
+  rules:
+  - direction: ingress
+    protocol: tcp
+    port: 161
+    remote_group: bob-b
+    ethertype: IPv4
+  description: bob-g

--- a/test/fixtures/cli/expected011.yaml
+++ b/test/fixtures/cli/expected011.yaml
@@ -1,0 +1,20 @@
+bob-b:
+  rules:
+  - direction: ingress
+    protocol: tcp
+    port: 443
+    remote_ip: 0.0.0.0/0
+    ethertype: IPv4
+  - direction: ingress
+    protocol: tcp
+    port: 80
+    remote_ip: 0.0.0.0/0
+    ethertype: IPv4
+  description: bob-b
+bob-c:
+  rules:
+  - direction: ingress
+    protocol: tcp
+    port: 443
+    remote_ip: 0.0.0.0/0
+    ethertype: IPv4

--- a/test/fixtures/cli/expected012.yaml
+++ b/test/fixtures/cli/expected012.yaml
@@ -1,0 +1,20 @@
+bob-b:
+  rules:
+  - direction: ingress
+    protocol: tcp
+    port: 443
+    remote_ip: 0.0.0.0/0
+    ethertype: IPv4
+  - direction: ingress
+    protocol: tcp
+    port: 80
+    remote_ip: 0.0.0.0/0
+    ethertype: IPv4
+  description: bob-b
+bob-c:
+  rules:
+  - direction: ingress
+    protocol: tcp
+    port: 443
+    remote_ip: 0.0.0.0/0
+  description: bob-c

--- a/test/fixtures/cli/expected012.yaml
+++ b/test/fixtures/cli/expected012.yaml
@@ -18,3 +18,11 @@ bob-c:
     port: 443
     remote_ip: 0.0.0.0/0
   description: bob-c
+bob-g:
+  rules:
+  - direction: ingress
+    protocol: tcp
+    port: 161
+    remote_group: bob-b
+    ethertype: IPv4
+  description: bob-g

--- a/test/fixtures/parser/actual.yaml
+++ b/test/fixtures/parser/actual.yaml
@@ -4,10 +4,12 @@ bob-b:
     protocol: tcp
     port: 443
     remote_ip: 0.0.0.0/0
+    ethertype: IPv4
   - direction: ingress
     protocol: tcp
     port: 80
     remote_ip: 0.0.0.0/0
+    ethertype: IPv4
   description: bob-b
 bob-c:
   rules:
@@ -15,4 +17,5 @@ bob-c:
     protocol: tcp
     port: 443
     remote_ip: 0.0.0.0/0
+    ethertype: IPv4
   description: bob-c

--- a/test/test_kakine_cli.rb
+++ b/test/test_kakine_cli.rb
@@ -17,15 +17,15 @@ class TestKakineCLI < Minitest::Test
 
   def test_create_security_group_with_rule
 
-    Kakine::Adapter::Mock.any_instance.expects(:create_security_group).once
-    Kakine::Adapter::Mock.any_instance.expects(:create_rule).twice
+    Kakine::Adapter::Mock.any_instance.expects(:create_security_group).twice
+    Kakine::Adapter::Mock.any_instance.expects(:create_rule).times(3)
 
     Kakine::CLI.new.invoke(:apply, [], {dryrun: true, filename: "test/fixtures/cli/expected002.yaml"})
   end
 
   def test_delete_security_group
 
-    Kakine::Adapter::Mock.any_instance.expects(:delete_security_group).once
+    Kakine::Adapter::Mock.any_instance.expects(:delete_security_group).twice
 
     Kakine::CLI.new.invoke(:apply, [], {dryrun: true, filename: "test/fixtures/cli/expected003.yaml"})
   end
@@ -33,22 +33,22 @@ class TestKakineCLI < Minitest::Test
   def test_create_security_group_rule
 
     Kakine::Adapter::Mock.any_instance.expects(:delete_rule).times(2)
-    Kakine::Adapter::Mock.any_instance.expects(:create_rule).times(3)
+    Kakine::Adapter::Mock.any_instance.expects(:create_rule).times(4)
 
     Kakine::CLI.new.invoke(:apply, [], {dryrun: true, filename: "test/fixtures/cli/expected004.yaml"})
   end
 
   def test_delete_security_group_rule
 
-    Kakine::Adapter::Mock.any_instance.expects(:delete_rule).once
+    Kakine::Adapter::Mock.any_instance.expects(:delete_rule).twice
 
     Kakine::CLI.new.invoke(:apply, [], {dryrun: true, filename: "test/fixtures/cli/expected005.yaml"})
   end
 
   def test_update_security_group_rule
 
-    Kakine::Adapter::Mock.any_instance.expects(:create_rule).twice
-    Kakine::Adapter::Mock.any_instance.expects(:delete_rule).twice
+    Kakine::Adapter::Mock.any_instance.expects(:create_rule).times(3)
+    Kakine::Adapter::Mock.any_instance.expects(:delete_rule).times(3)
 
     Kakine::CLI.new.invoke(:apply, [], {dryrun: true, filename: "test/fixtures/cli/expected006.yaml"})
   end

--- a/test/test_kakine_cli.rb
+++ b/test/test_kakine_cli.rb
@@ -2,11 +2,11 @@ require 'minitest_helper'
 
 class TestKakineCLI < Minitest::Test
   def setup
-    Kakine::Resource.stubs(:security_groups_hash).returns(YAML.load_file('test/fixtures/cli/actual.yaml'))
+    Kakine::Resource.stubs(:security_groups_hash).returns(Hash[YAML.load_file('test/fixtures/cli/actual.yaml').to_hash.sort].sg_rules_sort)
   end
 
   def test_create_security_group
-    Kakine::Resource.stubs(:yaml).returns(YAML.load_file('test/fixtures/cli/expected001.yaml'))
+    Kakine::Resource.stubs(:yaml).returns(Hash[YAML.load_file('test/fixtures/cli/expected001.yaml').to_hash.sort].sg_rules_sort)
     Kakine::Resource.stubs(:tenant).returns(Dummy.new)
     Kakine::Resource.stubs(:security_group).returns(Dummy.new)
     Kakine::Resource.stubs(:security_group_rule).returns(Dummy.new)
@@ -17,7 +17,7 @@ class TestKakineCLI < Minitest::Test
   end
 
   def test_create_security_group_with_rule
-    Kakine::Resource.stubs(:yaml).returns(YAML.load_file('test/fixtures/cli/expected002.yaml'))
+    Kakine::Resource.stubs(:yaml).returns(Hash[YAML.load_file('test/fixtures/cli/expected002.yaml').to_hash.sort].sg_rules_sort)
     Kakine::Resource.stubs(:tenant).returns(Dummy.new)
     Kakine::Resource.stubs(:security_group).returns(Dummy.new)
     Kakine::Resource.stubs(:security_group_rule).returns(Dummy.new)
@@ -29,7 +29,7 @@ class TestKakineCLI < Minitest::Test
   end
 
   def test_delete_security_group
-    Kakine::Resource.stubs(:yaml).returns(YAML.load_file('test/fixtures/cli/expected003.yaml'))
+    Kakine::Resource.stubs(:yaml).returns(Hash[YAML.load_file('test/fixtures/cli/expected003.yaml').to_hash.sort].sg_rules_sort)
     Kakine::Resource.stubs(:security_group).returns(Dummy.new)
     Kakine::Resource.stubs(:tenant).returns(Dummy.new)
 
@@ -39,18 +39,19 @@ class TestKakineCLI < Minitest::Test
   end
 
   def test_create_security_group_rule
-    Kakine::Resource.stubs(:yaml).returns(YAML.load_file('test/fixtures/cli/expected004.yaml'))
+    Kakine::Resource.stubs(:yaml).returns(Hash[YAML.load_file('test/fixtures/cli/expected004.yaml').to_hash.sort].sg_rules_sort)
     Kakine::Resource.stubs(:tenant).returns(Dummy.new)
     Kakine::Resource.stubs(:security_group).returns(Dummy.new)
     Kakine::Resource.stubs(:security_group_rule).returns(Dummy.new)
 
-    Kakine::Adapter::Mock.any_instance.expects(:create_rule).once
+    Kakine::Adapter::Mock.any_instance.expects(:delete_rule).times(2)
+    Kakine::Adapter::Mock.any_instance.expects(:create_rule).times(3)
 
     Kakine::CLI.new.invoke(:apply, [], {dryrun: true})
   end
 
   def test_delete_security_group_rule
-    Kakine::Resource.stubs(:yaml).returns(YAML.load_file('test/fixtures/cli/expected005.yaml'))
+    Kakine::Resource.stubs(:yaml).returns(Hash[YAML.load_file('test/fixtures/cli/expected005.yaml').to_hash.sort].sg_rules_sort)
     Kakine::Resource.stubs(:security_group).returns(Dummy.new)
     Kakine::Resource.stubs(:tenant).returns(Dummy.new)
     Kakine::Resource.stubs(:security_group_rule).returns(Dummy.new)
@@ -61,19 +62,45 @@ class TestKakineCLI < Minitest::Test
   end
 
   def test_update_security_group_rule
-    Kakine::Resource.stubs(:yaml).returns(YAML.load_file('test/fixtures/cli/expected006.yaml'))
+    Kakine::Resource.stubs(:yaml).returns(Hash[YAML.load_file('test/fixtures/cli/expected006.yaml').to_hash.sort].sg_rules_sort)
     Kakine::Resource.stubs(:tenant).returns(Dummy.new)
     Kakine::Resource.stubs(:security_group).returns(Dummy.new)
     Kakine::Resource.stubs(:security_group_rule).returns(Dummy.new)
 
-    Kakine::Adapter::Mock.any_instance.expects(:create_rule).once
-    Kakine::Adapter::Mock.any_instance.expects(:delete_rule).once
+    Kakine::Adapter::Mock.any_instance.expects(:create_rule).twice
+    Kakine::Adapter::Mock.any_instance.expects(:delete_rule).twice
 
     Kakine::CLI.new.invoke(:apply, [], {dryrun: true})
   end
 
   def test_update_security_group_description
-    Kakine::Resource.stubs(:yaml).returns(YAML.load_file('test/fixtures/cli/expected007.yaml'))
+    Kakine::Resource.stubs(:yaml).returns(Hash[YAML.load_file('test/fixtures/cli/expected007.yaml').to_hash.sort].sg_rules_sort)
+    Kakine::Resource.stubs(:tenant).returns(Dummy.new)
+    Kakine::Resource.stubs(:security_group).returns(Dummy.new)
+    Kakine::Resource.stubs(:security_group_rule).returns(Dummy.new)
+
+    Kakine::Adapter::Mock.any_instance.expects(:delete_security_group).once
+    Kakine::Adapter::Mock.any_instance.expects(:create_security_group).once
+
+    Kakine::CLI.new.invoke(:apply, [], {dryrun: true})
+  end
+
+  def test_change_rule_position
+    Kakine::Resource.stubs(:yaml).returns(Hash[YAML.load_file('test/fixtures/cli/expected008.yaml').to_hash.sort].sg_rules_sort)
+    Kakine::Resource.stubs(:tenant).returns(Dummy.new)
+    Kakine::Resource.stubs(:security_group).returns(Dummy.new)
+    Kakine::Resource.stubs(:security_group_rule).returns(Dummy.new)
+
+    Kakine::Adapter::Mock.any_instance.expects(:delete_security_group).never
+    Kakine::Adapter::Mock.any_instance.expects(:create_security_group).never
+    Kakine::Adapter::Mock.any_instance.expects(:create_rule).never
+    Kakine::Adapter::Mock.any_instance.expects(:delete_rule).never
+
+    Kakine::CLI.new.invoke(:apply, [], {dryrun: true})
+  end
+
+  def test_no_rule_group
+    Kakine::Resource.stubs(:yaml).returns(Hash[YAML.load_file('test/fixtures/cli/expected009.yaml').to_hash.sort].sg_rules_sort)
     Kakine::Resource.stubs(:tenant).returns(Dummy.new)
     Kakine::Resource.stubs(:security_group).returns(Dummy.new)
     Kakine::Resource.stubs(:security_group_rule).returns(Dummy.new)

--- a/test/test_kakine_cli.rb
+++ b/test/test_kakine_cli.rb
@@ -6,18 +6,16 @@ class TestKakineCLI < Minitest::Test
   end
 
   def test_create_security_group
-    Kakine::Resource.stubs(:yaml).returns(Hash[YAML.load_file('test/fixtures/cli/expected001.yaml').to_hash.sort].sg_rules_sort)
     Kakine::Resource.stubs(:tenant).returns(Dummy.new)
     Kakine::Resource.stubs(:security_group).returns(Dummy.new)
     Kakine::Resource.stubs(:security_group_rule).returns(Dummy.new)
 
     Kakine::Adapter::Mock.any_instance.expects(:create_security_group).once
 
-    Kakine::CLI.new.invoke(:apply, [], {dryrun: true})
+    Kakine::CLI.new.invoke(:apply, [], {dryrun: true, filename: "test/fixtures/cli/expected001.yaml"})
   end
 
   def test_create_security_group_with_rule
-    Kakine::Resource.stubs(:yaml).returns(Hash[YAML.load_file('test/fixtures/cli/expected002.yaml').to_hash.sort].sg_rules_sort)
     Kakine::Resource.stubs(:tenant).returns(Dummy.new)
     Kakine::Resource.stubs(:security_group).returns(Dummy.new)
     Kakine::Resource.stubs(:security_group_rule).returns(Dummy.new)
@@ -25,21 +23,19 @@ class TestKakineCLI < Minitest::Test
     Kakine::Adapter::Mock.any_instance.expects(:create_security_group).once
     Kakine::Adapter::Mock.any_instance.expects(:create_rule).twice
 
-    Kakine::CLI.new.invoke(:apply, [], {dryrun: true})
+    Kakine::CLI.new.invoke(:apply, [], {dryrun: true, filename: "test/fixtures/cli/expected002.yaml"})
   end
 
   def test_delete_security_group
-    Kakine::Resource.stubs(:yaml).returns(Hash[YAML.load_file('test/fixtures/cli/expected003.yaml').to_hash.sort].sg_rules_sort)
     Kakine::Resource.stubs(:security_group).returns(Dummy.new)
     Kakine::Resource.stubs(:tenant).returns(Dummy.new)
 
     Kakine::Adapter::Mock.any_instance.expects(:delete_security_group).once
 
-    Kakine::CLI.new.invoke(:apply, [], {dryrun: true})
+    Kakine::CLI.new.invoke(:apply, [], {dryrun: true, filename: "test/fixtures/cli/expected003.yaml"})
   end
 
   def test_create_security_group_rule
-    Kakine::Resource.stubs(:yaml).returns(Hash[YAML.load_file('test/fixtures/cli/expected004.yaml').to_hash.sort].sg_rules_sort)
     Kakine::Resource.stubs(:tenant).returns(Dummy.new)
     Kakine::Resource.stubs(:security_group).returns(Dummy.new)
     Kakine::Resource.stubs(:security_group_rule).returns(Dummy.new)
@@ -47,22 +43,20 @@ class TestKakineCLI < Minitest::Test
     Kakine::Adapter::Mock.any_instance.expects(:delete_rule).times(2)
     Kakine::Adapter::Mock.any_instance.expects(:create_rule).times(3)
 
-    Kakine::CLI.new.invoke(:apply, [], {dryrun: true})
+    Kakine::CLI.new.invoke(:apply, [], {dryrun: true, filename: "test/fixtures/cli/expected004.yaml"})
   end
 
   def test_delete_security_group_rule
-    Kakine::Resource.stubs(:yaml).returns(Hash[YAML.load_file('test/fixtures/cli/expected005.yaml').to_hash.sort].sg_rules_sort)
     Kakine::Resource.stubs(:security_group).returns(Dummy.new)
     Kakine::Resource.stubs(:tenant).returns(Dummy.new)
     Kakine::Resource.stubs(:security_group_rule).returns(Dummy.new)
 
     Kakine::Adapter::Mock.any_instance.expects(:delete_rule).once
 
-    Kakine::CLI.new.invoke(:apply, [], {dryrun: true})
+    Kakine::CLI.new.invoke(:apply, [], {dryrun: true, filename: "test/fixtures/cli/expected005.yaml"})
   end
 
   def test_update_security_group_rule
-    Kakine::Resource.stubs(:yaml).returns(Hash[YAML.load_file('test/fixtures/cli/expected006.yaml').to_hash.sort].sg_rules_sort)
     Kakine::Resource.stubs(:tenant).returns(Dummy.new)
     Kakine::Resource.stubs(:security_group).returns(Dummy.new)
     Kakine::Resource.stubs(:security_group_rule).returns(Dummy.new)
@@ -70,11 +64,10 @@ class TestKakineCLI < Minitest::Test
     Kakine::Adapter::Mock.any_instance.expects(:create_rule).twice
     Kakine::Adapter::Mock.any_instance.expects(:delete_rule).twice
 
-    Kakine::CLI.new.invoke(:apply, [], {dryrun: true})
+    Kakine::CLI.new.invoke(:apply, [], {dryrun: true, filename: "test/fixtures/cli/expected006.yaml"})
   end
 
   def test_update_security_group_description
-    Kakine::Resource.stubs(:yaml).returns(Hash[YAML.load_file('test/fixtures/cli/expected007.yaml').to_hash.sort].sg_rules_sort)
     Kakine::Resource.stubs(:tenant).returns(Dummy.new)
     Kakine::Resource.stubs(:security_group).returns(Dummy.new)
     Kakine::Resource.stubs(:security_group_rule).returns(Dummy.new)
@@ -82,11 +75,10 @@ class TestKakineCLI < Minitest::Test
     Kakine::Adapter::Mock.any_instance.expects(:delete_security_group).once
     Kakine::Adapter::Mock.any_instance.expects(:create_security_group).once
 
-    Kakine::CLI.new.invoke(:apply, [], {dryrun: true})
+    Kakine::CLI.new.invoke(:apply, [], {dryrun: true, filename: "test/fixtures/cli/expected007.yaml"})
   end
 
   def test_change_rule_position
-    Kakine::Resource.stubs(:yaml).returns(Hash[YAML.load_file('test/fixtures/cli/expected008.yaml').to_hash.sort].sg_rules_sort)
     Kakine::Resource.stubs(:tenant).returns(Dummy.new)
     Kakine::Resource.stubs(:security_group).returns(Dummy.new)
     Kakine::Resource.stubs(:security_group_rule).returns(Dummy.new)
@@ -96,18 +88,17 @@ class TestKakineCLI < Minitest::Test
     Kakine::Adapter::Mock.any_instance.expects(:create_rule).never
     Kakine::Adapter::Mock.any_instance.expects(:delete_rule).never
 
-    Kakine::CLI.new.invoke(:apply, [], {dryrun: true})
+    Kakine::CLI.new.invoke(:apply, [], {dryrun: true, filename: "test/fixtures/cli/expected008.yaml"})
   end
 
   def test_no_rule_group
-    Kakine::Resource.stubs(:yaml).returns(Hash[YAML.load_file('test/fixtures/cli/expected009.yaml').to_hash.sort].sg_rules_sort)
     Kakine::Resource.stubs(:tenant).returns(Dummy.new)
     Kakine::Resource.stubs(:security_group).returns(Dummy.new)
     Kakine::Resource.stubs(:security_group_rule).returns(Dummy.new)
 
-    Kakine::Adapter::Mock.any_instance.expects(:delete_security_group).once
-    Kakine::Adapter::Mock.any_instance.expects(:create_security_group).once
+    Kakine::Adapter::Mock.any_instance.expects(:delete_rule).twice
+    Kakine::Adapter::Mock.any_instance.expects(:delete_security_group).never
 
-    Kakine::CLI.new.invoke(:apply, [], {dryrun: true})
+    Kakine::CLI.new.invoke(:apply, [], {dryrun: true, filename: "test/fixtures/cli/expected009.yaml"})
   end
 end

--- a/test/test_kakine_cli.rb
+++ b/test/test_kakine_cli.rb
@@ -3,12 +3,12 @@ require 'minitest_helper'
 class TestKakineCLI < Minitest::Test
   def setup
     Kakine::Resource.stubs(:security_groups_hash).returns(Hash[YAML.load_file('test/fixtures/cli/actual.yaml').to_hash.sort].sg_rules_sort)
-  end
-
-  def test_create_security_group
     Kakine::Resource.stubs(:tenant).returns(Dummy.new)
     Kakine::Resource.stubs(:security_group).returns(Dummy.new)
     Kakine::Resource.stubs(:security_group_rule).returns(Dummy.new)
+  end
+
+  def test_create_security_group
 
     Kakine::Adapter::Mock.any_instance.expects(:create_security_group).once
 
@@ -16,9 +16,6 @@ class TestKakineCLI < Minitest::Test
   end
 
   def test_create_security_group_with_rule
-    Kakine::Resource.stubs(:tenant).returns(Dummy.new)
-    Kakine::Resource.stubs(:security_group).returns(Dummy.new)
-    Kakine::Resource.stubs(:security_group_rule).returns(Dummy.new)
 
     Kakine::Adapter::Mock.any_instance.expects(:create_security_group).once
     Kakine::Adapter::Mock.any_instance.expects(:create_rule).twice
@@ -27,8 +24,6 @@ class TestKakineCLI < Minitest::Test
   end
 
   def test_delete_security_group
-    Kakine::Resource.stubs(:security_group).returns(Dummy.new)
-    Kakine::Resource.stubs(:tenant).returns(Dummy.new)
 
     Kakine::Adapter::Mock.any_instance.expects(:delete_security_group).once
 
@@ -36,9 +31,6 @@ class TestKakineCLI < Minitest::Test
   end
 
   def test_create_security_group_rule
-    Kakine::Resource.stubs(:tenant).returns(Dummy.new)
-    Kakine::Resource.stubs(:security_group).returns(Dummy.new)
-    Kakine::Resource.stubs(:security_group_rule).returns(Dummy.new)
 
     Kakine::Adapter::Mock.any_instance.expects(:delete_rule).times(2)
     Kakine::Adapter::Mock.any_instance.expects(:create_rule).times(3)
@@ -47,9 +39,6 @@ class TestKakineCLI < Minitest::Test
   end
 
   def test_delete_security_group_rule
-    Kakine::Resource.stubs(:security_group).returns(Dummy.new)
-    Kakine::Resource.stubs(:tenant).returns(Dummy.new)
-    Kakine::Resource.stubs(:security_group_rule).returns(Dummy.new)
 
     Kakine::Adapter::Mock.any_instance.expects(:delete_rule).once
 
@@ -57,9 +46,6 @@ class TestKakineCLI < Minitest::Test
   end
 
   def test_update_security_group_rule
-    Kakine::Resource.stubs(:tenant).returns(Dummy.new)
-    Kakine::Resource.stubs(:security_group).returns(Dummy.new)
-    Kakine::Resource.stubs(:security_group_rule).returns(Dummy.new)
 
     Kakine::Adapter::Mock.any_instance.expects(:create_rule).twice
     Kakine::Adapter::Mock.any_instance.expects(:delete_rule).twice
@@ -68,9 +54,6 @@ class TestKakineCLI < Minitest::Test
   end
 
   def test_update_security_group_description
-    Kakine::Resource.stubs(:tenant).returns(Dummy.new)
-    Kakine::Resource.stubs(:security_group).returns(Dummy.new)
-    Kakine::Resource.stubs(:security_group_rule).returns(Dummy.new)
 
     Kakine::Adapter::Mock.any_instance.expects(:delete_security_group).once
     Kakine::Adapter::Mock.any_instance.expects(:create_security_group).once
@@ -79,9 +62,6 @@ class TestKakineCLI < Minitest::Test
   end
 
   def test_change_rule_position
-    Kakine::Resource.stubs(:tenant).returns(Dummy.new)
-    Kakine::Resource.stubs(:security_group).returns(Dummy.new)
-    Kakine::Resource.stubs(:security_group_rule).returns(Dummy.new)
 
     Kakine::Adapter::Mock.any_instance.expects(:delete_security_group).never
     Kakine::Adapter::Mock.any_instance.expects(:create_security_group).never
@@ -92,13 +72,37 @@ class TestKakineCLI < Minitest::Test
   end
 
   def test_no_rule_group
-    Kakine::Resource.stubs(:tenant).returns(Dummy.new)
-    Kakine::Resource.stubs(:security_group).returns(Dummy.new)
-    Kakine::Resource.stubs(:security_group_rule).returns(Dummy.new)
 
     Kakine::Adapter::Mock.any_instance.expects(:delete_rule).twice
     Kakine::Adapter::Mock.any_instance.expects(:delete_security_group).never
 
     Kakine::CLI.new.invoke(:apply, [], {dryrun: true, filename: "test/fixtures/cli/expected009.yaml"})
+  end
+  def test_validate_rules
+
+    Kakine::Adapter::Mock.any_instance.expects(:delete_security_group).never
+    Kakine::Adapter::Mock.any_instance.expects(:create_security_group).never
+    Kakine::Adapter::Mock.any_instance.expects(:create_rule).never
+    Kakine::Adapter::Mock.any_instance.expects(:delete_rule).never
+
+    Kakine::CLI.new.invoke(:apply, [], {dryrun: true, filename: "test/fixtures/cli/expected010.yaml"})
+  end
+  def test_validate_description
+
+    Kakine::Adapter::Mock.any_instance.expects(:delete_security_group).never
+    Kakine::Adapter::Mock.any_instance.expects(:create_security_group).never
+    Kakine::Adapter::Mock.any_instance.expects(:create_rule).never
+    Kakine::Adapter::Mock.any_instance.expects(:delete_rule).never
+
+    Kakine::CLI.new.invoke(:apply, [], {dryrun: true, filename: "test/fixtures/cli/expected011.yaml"})
+  end
+  def test_validate_attributes
+
+    Kakine::Adapter::Mock.any_instance.expects(:delete_security_group).never
+    Kakine::Adapter::Mock.any_instance.expects(:create_security_group).never
+    Kakine::Adapter::Mock.any_instance.expects(:create_rule).never
+    Kakine::Adapter::Mock.any_instance.expects(:delete_rule).never
+
+    Kakine::CLI.new.invoke(:apply, [], {dryrun: true, filename: "test/fixtures/cli/expected012.yaml"})
   end
 end

--- a/test/test_kakine_parser.rb
+++ b/test/test_kakine_parser.rb
@@ -1,6 +1,6 @@
 require 'minitest_helper'
 
-class TestKakineCLI < Minitest::Test
+class TestKakineDiffParser < Minitest::Test
   def setup
     Kakine::Resource.stubs(:security_groups_hash).returns(YAML.load_file('test/fixtures/parser/actual.yaml'))
     Kakine::Resource.stubs(:tenant).returns(Dummy.new)
@@ -54,8 +54,8 @@ class TestKakineCLI < Minitest::Test
     assert_equal(sg.tenant_id, Dummy.new.id)
     assert_equal(sg.tenant_name, Dummy.new.id)
     assert_equal(sg.description, "change_description")
-    assert_equal(sg.rules, [{"direction"=>"ingress", "protocol"=>"tcp", "port"=>443, "remote_ip"=>"0.0.0.0/0"},
-    {"direction"=>"ingress", "protocol"=>"tcp", "port"=>80, "remote_ip"=>"0.0.0.0/0"}])
+    assert_equal(sg.rules, [{"direction"=>"ingress", "protocol"=>"tcp", "port"=>443, "remote_ip"=>"0.0.0.0/0", "ethertype"=>"IPv4"},
+    {"direction"=>"ingress", "protocol"=>"tcp", "port"=>80, "remote_ip"=>"0.0.0.0/0", "ethertype"=>"IPv4"}])
   end
 
   def test_update_security_group_attributes
@@ -65,6 +65,6 @@ class TestKakineCLI < Minitest::Test
     assert_equal(sg.tenant_id, Dummy.new.id)
     assert_equal(sg.tenant_name, Dummy.new.id)
     assert_equal(sg.description, "bob-b")
-    assert_equal(sg.rules, [{"direction"=>"ingress", "protocol"=>"tcp", "port"=>1000, "remote_ip"=>"0.0.0.0/0"}])
+    assert_equal(sg.rules, [{"direction"=>"ingress", "protocol"=>"tcp", "port"=>1000, "remote_ip"=>"0.0.0.0/0", "ethertype"=>"IPv4"}])
   end
 end


### PR DESCRIPTION
## このPRでは下記のことを作業しています
- 取得した差分を変更、削除、追加順で処理を行う
- SGの対象がセキュリティグループであった場合に、ethが判別されない不具合を修正
- 読み込んだyamlファイルのSGごとの必須項目チェックを行う
- HTTP 409エラーをサポート
