### PR TITLE
member権限で使えるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ default:
   openstack_username: "admin"
   openstack_tenant: "admin"
   openstack_api_key: "admin-no-password"
+  openstack_identity_endpoint: "http://your-openstack-endpoint:5000/v2.0"
 ```
 
 run following command.

--- a/lib/kakine/resource.rb
+++ b/lib/kakine/resource.rb
@@ -20,7 +20,7 @@ module Kakine
       end
 
       def tenant(tenant_name)
-        @tenant ||= Fog::Identity[:openstack].tenants.detect{|t| t.name == tenant_name}
+        @tenant ||= Fog::Compute[:openstack].tenants.detect{|t| t.name == tenant_name}
       end
 
       def security_group(tenant_name, security_group_name)


### PR DESCRIPTION
`admin` 権限を持っていなくても `member` 権限があればsg設定できるようにしたいです。
`Fog::Identity`の`:tenants` は `admin`権限 がないと `403 Forbidden` になってしまうので、代わりに`Fog::Compute`の`:tenants` を使うようにしました。
