### PR TITLE
Use OS_* environment variables

### DIFF
--- a/lib/kakine/config.rb
+++ b/lib/kakine/config.rb
@@ -4,7 +4,7 @@ require 'yaml'
 module Kakine
   class Config
     @@auth_url       = nil
-    @@tenant         = nil
+    @@tenant_name    = nil
     @@username       = nil
     @@password       = nil
 
@@ -24,7 +24,7 @@ module Kakine
       config = YAML.load_file(config_file)
 
       @@auth_url       = config['auth_url']
-      @@tenant         = config['tenant']
+      @@tenant_name    = config['tenant_name'] || config['tenant']  # for compatibility
       @@username       = config['username']
       @@password       = config['password']
       true
@@ -32,13 +32,13 @@ module Kakine
 
     def self.load_env
       @@auth_url       = ENV['OS_AUTH_URL'] if ENV['OS_AUTH_URL']
-      @@tenant         = ENV['OS_TENANT_NAME'] if ENV['OS_TENANT_NAME']
+      @@tenant_name    = ENV['OS_TENANT_NAME'] if ENV['OS_TENANT_NAME']
       @@username       = ENV['OS_USERNAME'] if ENV['OS_USERNAME']
       @@password       = ENV['OS_PASSWORD'] if ENV['OS_PASSWORD']
     end
 
     def self.validate_config
-      %w[auth_url tenant username password].each do |conf_item|
+      %w[auth_url tenant_name username password].each do |conf_item|
         unless class_variable_get("@@#{conf_item}")
           raise "Configuration '#{conf_item}' is missing. Check your ~/.kakine or export OS_#{conf_item.upcase}"
         end
@@ -48,7 +48,7 @@ module Kakine
     def self.setup_yao
       Yao.configure do
         auth_url    @@auth_url
-        tenant_name @@tenant
+        tenant_name @@tenant_name
         username    @@username
         password    @@password
       end

--- a/lib/kakine/config.rb
+++ b/lib/kakine/config.rb
@@ -3,8 +3,15 @@ require 'yaml'
 
 module Kakine
   class Config
+    @@auth_url       = nil
+    @@tenant         = nil
+    @@username       = nil
+    @@password       = nil
+
     def self.setup
       load_config
+      load_env
+      validate_config
       setup_yao
     end
 
@@ -12,19 +19,30 @@ module Kakine
 
     def self.load_config
       config_file = File.join(Dir.home, '.kakine')
-      raise '~/.kakine is missing' unless File.exists?(config_file)
+      return false unless File.exists?(config_file)
 
       config = YAML.load_file(config_file)
-
-      %w[auth_url tenant username password].each do |conf_item|
-        raise "Configuration '#{conf_item}' is missing. Check your ~/.kakine" unless config[conf_item]
-      end
 
       @@auth_url       = config['auth_url']
       @@tenant         = config['tenant']
       @@username       = config['username']
       @@password       = config['password']
       true
+    end
+
+    def self.load_env
+      @@auth_url       = ENV['OS_AUTH_URL'] if ENV['OS_AUTH_URL']
+      @@tenant         = ENV['OS_TENANT_NAME'] if ENV['OS_TENANT_NAME']
+      @@username       = ENV['OS_USERNAME'] if ENV['OS_USERNAME']
+      @@password       = ENV['OS_PASSWORD'] if ENV['OS_PASSWORD']
+    end
+
+    def self.validate_config
+      %w[auth_url tenant username password].each do |conf_item|
+        unless class_variable_get("@@#{conf_item}")
+          raise "Configuration '#{conf_item}' is missing. Check your ~/.kakine or export OS_#{conf_item.upcase}"
+        end
+      end
     end
 
     def self.setup_yao


### PR DESCRIPTION
I don't like storing my OpenStack credential in a file and would like to use standard OS_\* environment variables that many other tools for OpenStack adopt.
It was possible in kakine version 0.3.
