### PR TITLE
Allow defining "meta section" in YAML config

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ Or install it yourself as:
 
 ## Usage
 
-You can define Security Group configuration for OpenStack via YAML format. Like following syntax.
+### Syntax
+
+You can define Security Group configuration for OpenStack in YAML format as the following example.
 
 ```yaml
 app:
@@ -44,6 +46,30 @@ rails:
       remote_ip: 0.0.0.0/0
 ```
 
+
+Top-level keys whose name both starts and ends with underscores (eg. `_common_`, `_default_`) are considered **meta sections** and do not correspond to security groups.
+These sections are useful to define values that commonly appears throughout the file, used with YAML's anchors and references.
+
+```yaml
+_common_:
+  - &net1 192.0.2.0/24
+  - &net2 198.51.100.0/24
+
+restricted_web:
+  rules:
+  - direction: ingress
+    protocol: tcp
+    port: 80
+    remote_ip: *net1
+  - direction: ingress
+    protocol: tcp
+    port: 80
+    remote_ip: *net2
+  description: Restricted HTTP access
+```
+
+### Authentication configuration
+
 You need to put a configuration file to home directory.
 
 ```sh
@@ -53,6 +79,8 @@ username: "admin"
 tenant: "admin"
 password: "admin"
 ```
+
+### Commands
 
 run following command.
 

--- a/lib/kakine/resource/yaml.rb
+++ b/lib/kakine/resource/yaml.rb
@@ -9,7 +9,7 @@ module Kakine
         end
 
         def yaml(filename)
-          YAML.load_file(filename).to_hash
+          YAML.load_file(filename).to_hash.reject {|k, _| k.start_with?('_') && k.end_with?('_') }
         end
 
         def validate_file_input(load_sg)

--- a/test/fixtures/yaml/meta_section.yaml
+++ b/test/fixtures/yaml/meta_section.yaml
@@ -1,0 +1,18 @@
+_common_:
+  addrs:
+    - &ip1 192.168.10.5
+    - &ip2 192.168.10.6
+
+web:
+  rules:
+    - direction: ingress
+      ethertype: IPv4
+      protocol: tcp
+      port: 80
+      remote_ip: &ip1
+    - direction: ingress
+      ethertype: IPv4
+      protocol: tcp
+      port: 80
+      remote_ip: &ip2
+  description: Allow access to web

--- a/test/test_kakine_yaml.rb
+++ b/test/test_kakine_yaml.rb
@@ -1,0 +1,10 @@
+require 'minitest_helper'
+
+class TestKakineYaml < Minitest::Test
+  def test_meta_section
+    yaml = Kakine::Resource::Yaml.yaml('test/fixtures/yaml/meta_section.yaml')
+
+    assert_equal 1, yaml.size
+    assert_equal 2, yaml['web']['rules'].size
+  end
+end


### PR DESCRIPTION
Toplevel keys whose name starts and ends with underscores are just ignored.
They can be used to define miscellaneous values and referred to by YAML anchors.

See the test fixture for an example configuration.
