### PR TITLE
Rule expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ rails:
       remote_ip: 0.0.0.0/0
 ```
 
+`port`s and `remote_ip`s may be specified as arrays, in which case the rule is expanded to set of rules with all the combinations of them.
+```yaml
+app:
+  rules:
+    - direction: ingress
+      protocol: tcp
+      port: [80, 443]
+      remote_ip:
+        - 192.0.2.0/24
+        - 198.51.100.0/24
+```
+
 
 Top-level keys whose name both starts and ends with underscores (eg. `_common_`, `_default_`) are considered **meta sections** and do not correspond to security groups.
 These sections are useful to define values that commonly appears throughout the file, used with YAML's anchors and references.

--- a/test/fixtures/yaml/rule_expansion.yaml
+++ b/test/fixtures/yaml/rule_expansion.yaml
@@ -1,0 +1,51 @@
+sg_nil:
+  rules: []
+  description: no rules
+
+sg_port:
+  rules:
+    - direction: ingress
+      ethertype: IPv4
+      protocol: tcp
+      port: [22, 80, 443]
+      remote_ip: 192.168.10.0/24
+  description: expansion by port
+
+sg_remote_ip:
+  rules:
+    - direction: ingress
+      ethertype: IPv4
+      protocol: tcp
+      port: 22
+      remote_ip:
+        - 192.168.10.10
+        - 192.168.10.11
+  description: expansion by remote_ip
+
+sg_port_remote_ip:
+  rules:
+    - direction: ingress
+      ethertype: IPv4
+      protocol: tcp
+      port: [22, 80, 443]
+      remote_ip:
+        - 192.168.10.10
+        - 192.168.10.11
+  description: expansion by port and remote_ip
+
+
+_common_:
+  addrs:
+    - &net1 [192.168.10.20, 192.168.10.22]
+
+sg_remote_ip_nested:
+  rules:
+    - direction: ingress
+      ethertype: IPv4
+      protocol: tcp
+      port: 22
+      remote_ip:
+        - 192.168.10.10
+        - 192.168.10.11
+        - *net1
+  description: expansion by nested remote_ip

--- a/test/test_kakine_yaml.rb
+++ b/test/test_kakine_yaml.rb
@@ -2,9 +2,79 @@ require 'minitest_helper'
 
 class TestKakineYaml < Minitest::Test
   def test_meta_section
-    yaml = Kakine::Resource::Yaml.yaml('test/fixtures/yaml/meta_section.yaml')
+    yaml = Kakine::Resource::Yaml.load_file('test/fixtures/yaml/meta_section.yaml')
 
     assert_equal 1, yaml.size
     assert_equal 2, yaml['web']['rules'].size
+  end
+
+  def test_rule_expansion
+    yaml = Kakine::Resource::Yaml.load_file('test/fixtures/yaml/rule_expansion.yaml')
+
+    assert_equal [], yaml['sg_nil']['rules']
+
+    assert_equal 3, yaml['sg_port']['rules'].count
+
+    assert_equal 2, yaml['sg_remote_ip']['rules'].count
+
+    assert_equal 6, yaml['sg_port_remote_ip']['rules'].count
+
+    assert_equal 4, yaml['sg_remote_ip_nested']['rules'].count
+  end
+
+  def test_expand_rules
+    # empty input
+    assert_equal [], Kakine::Resource::Yaml.expand_rules([], 'key')
+
+    # empty hash
+    assert_equal [{}], Kakine::Resource::Yaml.expand_rules([{}], 'key')
+
+    # unrelated keys
+    assert_equal [{'other' => nil}], Kakine::Resource::Yaml.expand_rules([{'other' => nil}], 'key')
+    assert_equal [{'other' => {}}], Kakine::Resource::Yaml.expand_rules([{'other' => {}}], 'key')
+    assert_equal [{'other' => 0}], Kakine::Resource::Yaml.expand_rules([{'other' => 0}], 'key')
+    assert_equal [{'other' => []}], Kakine::Resource::Yaml.expand_rules([{'other' => []}], 'key')
+    assert_equal [{'other' => [0, 1]}], Kakine::Resource::Yaml.expand_rules([{'other' => [0, 1]}], 'key')
+
+    # scalar values
+    assert_equal [{'key' => 10}], Kakine::Resource::Yaml.expand_rules([{'key' => 10}], 'key')
+    assert_equal [{'key' => 10, 'other' => 0}], Kakine::Resource::Yaml.expand_rules([{'key' => 10, 'other' => 0}], 'key')
+
+    # empty arrays
+    assert_equal [], Kakine::Resource::Yaml.expand_rules([{'key' => []}], 'key')
+    assert_equal [], Kakine::Resource::Yaml.expand_rules([{'key' => [], 'other' => 0}], 'key')
+
+    # singleton arrays
+    assert_equal [{'key' => 10}], Kakine::Resource::Yaml.expand_rules([{'key' => [10]}], 'key')
+    assert_equal [{'key' => 10, 'other' => 0}], Kakine::Resource::Yaml.expand_rules([{'key' => [10], 'other' => 0}], 'key')
+
+    # arrays
+    assert_equal [{'key' => 10}, {'key' => 20}], Kakine::Resource::Yaml.expand_rules([{'key' => [10, 20]}], 'key')
+    assert_equal [{'key' => 10, 'other' => 0}, {'key' => 20, 'other' => 0}], Kakine::Resource::Yaml.expand_rules([{'key' => [10, 20], 'other' => 0}], 'key')
+
+    # nil is scalar
+    assert_equal [{'key' => nil}], Kakine::Resource::Yaml.expand_rules([{'key' => nil}], 'key')
+    assert_equal [{'key' => nil, 'other' => 0}], Kakine::Resource::Yaml.expand_rules([{'key' => nil, 'other' => 0}], 'key')
+
+    # singleton array of nil
+    assert_equal [{'key' => nil}], Kakine::Resource::Yaml.expand_rules([{'key' => [nil]}], 'key')
+    assert_equal [{'key' => nil, 'other' => 0}], Kakine::Resource::Yaml.expand_rules([{'key' => [nil], 'other' => 0}], 'key')
+
+    # nested arrays
+    assert_equal [], Kakine::Resource::Yaml.expand_rules([{'key' => [[]]}], 'key')
+    assert_equal [], Kakine::Resource::Yaml.expand_rules([{'key' => [[], []]}], 'key')
+    assert_equal [{'key' => nil}], Kakine::Resource::Yaml.expand_rules([{'key' => [[nil]]}], 'key')
+    assert_equal [{'key' => 10}, {'key' => 20}, {'key' => 30}], Kakine::Resource::Yaml.expand_rules([{'key' => [10, [20, 30]]}], 'key')
+
+    # multiple inputs
+    assert_equal [{}, {}], Kakine::Resource::Yaml.expand_rules([{}, {}], 'key')
+    assert_equal [{'other' => 0}, {'other' => 1}], Kakine::Resource::Yaml.expand_rules([{'other' => 0}, {'other' => 1}], 'key')
+    assert_equal [{'key' => 10}, {'key' => 20}], Kakine::Resource::Yaml.expand_rules([{'key' => 10}, {'key' => 20}], 'key')
+    assert_equal [{'key' => 10, 'other' => 0}, {'key' => 20}], Kakine::Resource::Yaml.expand_rules([{'key' => 10, 'other' => 0}, {'key' => 20}], 'key')
+    assert_equal [{'key' => 10}, {'key' => 20}, {'key' => 30}], Kakine::Resource::Yaml.expand_rules([{'key' => 10}, {'key' => [20, 30]}], 'key')
+
+    # matrix expansion
+    assert_equal [{'key0' => 10, 'key1' => 50}, {'key0' => 10, 'key1' => 60}, {'key0' => 20, 'key1' => 50}, {'key0' => 20, 'key1' => 60}],
+                 Kakine::Resource::Yaml.expand_rules(Kakine::Resource::Yaml.expand_rules([{'key0' => [10, 20], 'key1' => [50, 60]}], 'key0'), 'key1')
   end
 end


### PR DESCRIPTION
It is often the case allowing accesses to a certain set of port numbers (say [80, 443]) from a certain set of remote addresses (say [A, B, C]). In that case we have to write an array of 2×3=6 rules in the YAML configuration, which is too redundant and bug-prone.

I would like to add a feature to expand the matrix of `port`s and `remote_ip`s specified as arrays in the YAML into actual rules. How do you like this idea?

With this concept implementation you can write the six SG rules as the following:

``` yaml
sg:
  rules:
    - direction: ingress
      ethertype: IPv4
      protocol: tcp
      port: [80, 443]
      remote_ip: [A, B, C]
```
