### PR TITLE
Expanding rules for multiple protocols

### DIFF
--- a/lib/kakine/resource/yaml.rb
+++ b/lib/kakine/resource/yaml.rb
@@ -93,7 +93,7 @@ module Kakine
         end
 
         def perform_expansion(rules)
-          %w(remote_ip port).each do |key|
+          %w(remote_ip port protocol).each do |key|
             rules = expand_rules(rules, key)
           end
 

--- a/test/fixtures/yaml/rule_expansion.yaml
+++ b/test/fixtures/yaml/rule_expansion.yaml
@@ -49,3 +49,12 @@ sg_remote_ip_nested:
         - 192.168.10.11
         - *net1
   description: expansion by nested remote_ip
+
+sg_protocol:
+  rules:
+  - direction: ingress
+    protocol: [tcp, udp]
+    ethertype: IPv4
+    port: 53
+    remote_ip: 0.0.0.0/0
+  description: expansion by protocol

--- a/test/test_kakine_yaml.rb
+++ b/test/test_kakine_yaml.rb
@@ -20,6 +20,8 @@ class TestKakineYaml < Minitest::Test
     assert_equal 6, yaml['sg_port_remote_ip']['rules'].count
 
     assert_equal 4, yaml['sg_remote_ip_nested']['rules'].count
+
+    assert_equal 2, yaml['sg_protocol']['rules'].count
   end
 
   def test_expand_rules


### PR DESCRIPTION
In the same way as a0d9888, it supports a set of protocols (dns and ldap, etc...).

``` yaml
dns:
  rules:
  - direction: ingress
    protocol: [tcp, udp]
    ethertype: IPv4
    port: 53
    remote_ip: 0.0.0.0/0
  description: dns lookup
```
