### PR TITLE
Delete unrecognized attr for create_rule

### DIFF
--- a/lib/kakine/adapter/real.rb
+++ b/lib/kakine/adapter/real.rb
@@ -50,18 +50,15 @@ module Kakine
 
       def symbolized_rule(security_rule)
         attributes = {}
-        %w(protocol port_range_max port_range_min remote_ip ethertype).each do |k|
+        %w(protocol port_range_max port_range_min ethertype).each do |k|
           attributes[k.to_sym] = security_rule.send(k)
         end
 
         if security_rule.remote_group
           attributes[:remote_group_id] = security_rule.remote_group_id
-        else
-          attributes[:remote_ip_prefix] = attributes.delete(:remote_ip) if attributes[:remote_ip]
+        elsif security_rule.remote_ip
+          attributes[:remote_ip_prefix] = security_rule.remote_ip
         end
-
-        # Unrecognized attribute
-        attributes.delete(:remote_ip)
 
         attributes
       end

--- a/lib/kakine/adapter/real.rb
+++ b/lib/kakine/adapter/real.rb
@@ -59,6 +59,10 @@ module Kakine
         else
           attributes[:remote_ip_prefix] = attributes.delete(:remote_ip) if attributes[:remote_ip]
         end
+
+        # Unrecognized attribute
+        attributes.delete(:remote_ip)
+
         attributes
       end
     end


### PR DESCRIPTION
"remote_ip" is a unrecognized attribute so it should not be included in api's request.

API document: http://developer.openstack.org/api-ref/networking/v2/?expanded=create-security-group-rule-detail