### PR TITLE
Add convert subcommand to export Terraform configuration

### DIFF
--- a/lib/kakine.rb
+++ b/lib/kakine.rb
@@ -17,6 +17,8 @@ require 'kakine/resource/openstack'
 require 'kakine/resource/yaml'
 require 'kakine/security_group'
 require 'kakine/security_rule'
+require 'kakine/exporter'
+require 'kakine/exporter/terraform'
 
 module Kakine
   class Error < StandardError; end

--- a/lib/kakine/cli.rb
+++ b/lib/kakine/cli.rb
@@ -17,6 +17,18 @@ module Kakine
       Kakine::Director.apply
     end
 
+    option :tenant, type: :string, aliases: "-t"
+    option :filename, type: :string, aliases: "-f"
+    option :format, type: :string, aliases: '-F'
+    option :output, type: :string, aliases: '-o'
+    desc 'convert', 'convert Security Groups into other format'
+    def convert
+      format = options[:format] or fail '--format is required'
+      output = options[:output]
+      Kakine::Option.set_options(options)
+      Kakine::Director.convert(format, output)
+    end
+
     no_commands do
       def setup(options)
         Kakine::Option.set_options(options)

--- a/lib/kakine/director.rb
+++ b/lib/kakine/director.rb
@@ -18,8 +18,20 @@ module Kakine
 
         Kakine::Builder.clean_up_security_group(new_sgs, current_sgs)
 
-        rescue Kakine::Error => e
-          puts "[error] #{e}"
+      rescue Kakine::Error => e
+        puts "[error] #{e}"
+      end
+
+      def convert(format, output = nil)
+        sgs = Kakine::Resource.get(:yaml).load_security_group
+
+        file = output ? open(output, 'w') : $stdout.dup
+        begin
+          exporter = Kakine::Exporter.get(format).new(file)
+          exporter.export(sgs)
+        ensure
+          file.close
+        end
       end
     end
   end

--- a/lib/kakine/exporter.rb
+++ b/lib/kakine/exporter.rb
@@ -1,0 +1,12 @@
+module Kakine
+  module Exporter
+    def self.get(type)
+      case type.to_sym
+      when :terraform
+        Kakine::Exporter::Terraform
+      else
+        fail "Unknown exporter: #{type}"
+      end
+    end
+  end
+end

--- a/lib/kakine/exporter/terraform.rb
+++ b/lib/kakine/exporter/terraform.rb
@@ -1,0 +1,80 @@
+module Kakine
+  module Exporter
+    class Terraform
+      def initialize(output, pretty: true)
+        @output = output
+        @pretty = pretty
+      end
+
+      def export(security_groups)
+        write(generate(security_groups))
+      end
+
+      private
+
+      def write(tf)
+        @output.write(@pretty ? JSON.pretty_generate(tf) : JSON.generate(tf))
+      end
+
+      def generate(security_groups)
+        {
+          resource: {
+            'openstack_networking_secgroup_v2' => generate_security_groups(security_groups),
+            'openstack_networking_secgroup_rule_v2' => generate_security_group_rules(security_groups),
+          },
+        }
+      end
+
+      def generate_security_groups(security_groups)
+        security_groups.each.with_object({}) do |security_group, resources|
+          resources[sanitize(security_group.name)] = {
+            name: security_group.name,
+            description: security_group.description,
+          }
+        end
+      end
+
+      def generate_security_group_rules(security_groups)
+        security_groups.each.with_object({}) do |security_group, resources|
+          security_group.rules.each do |rule|
+            name = [sanitize(security_group.name), sanitize(identify(rule))].join('-')
+            resources[name] =  compact_hash(
+              direction: rule.direction,
+              ethertype: rule.ethertype,
+              protocol: rule.protocol,
+              port_range_min: rule.port_range_min,
+              port_range_max: rule.port_range_max,
+              remote_ip_prefix: rule.remote_ip,
+              remote_group_id: ("${openstack_networking_secgroup_v2.#{sanitize(rule.remote_group)}.id}" if rule.remote_group),
+              security_group_id: "${openstack_networking_secgroup_v2.#{sanitize(security_group.name)}.id}",
+            )
+          end
+        end
+      end
+
+      # Generates a unique name for a SG rule.
+      def identify(rule)
+        [
+          rule.direction,
+          rule.ethertype,
+          rule.protocol,
+          rule.port_range_min,
+          rule.port_range_max,
+          rule.remote_ip,
+          rule.remote_group,
+        ].compact.map(&method(:sanitize)).join('-')
+      end
+
+      # Returns a string that can be used as a Terraform resource name.
+      def sanitize(name)
+        name.to_s.gsub(/\W/, '_')
+      end
+
+      def compact_hash(hash)
+        return hash.compact if hash.respond_to?(:compact)
+        hash.each.with_object({}) {|(k, v), hash| hash[k] = v unless v.nil? }
+      end
+    end
+  end
+end
+

--- a/test/fixtures/simple.yaml
+++ b/test/fixtures/simple.yaml
@@ -1,0 +1,8 @@
+www:
+  description: Allow HTTP/HTTPS
+  rules:
+  - direction: ingress
+    ethertype: IPv4
+    port: [80, 443]
+    protocol: tcp
+    remote_ip: 192.0.2.0/24

--- a/test/test_kakine_cli.rb
+++ b/test/test_kakine_cli.rb
@@ -87,4 +87,11 @@ class TestKakineCLI < Minitest::Test
     Kakine::CLI.new.invoke(:apply, [], {dryrun: true})
   end
 
+  def test_convert_terraform
+    Kakine::Resource.get(:yaml).stubs(:yaml).returns(YAML.load_file('test/fixtures/simple.yaml'))
+
+    tempfile = Tempfile.new('')
+    Kakine::CLI.new.invoke(:convert, [], {format: 'terraform', output: tempfile.path})
+    refute Pathname.new(tempfile.path).size.zero?
+  end
 end

--- a/test/test_kakine_director.rb
+++ b/test/test_kakine_director.rb
@@ -1,0 +1,37 @@
+require 'minitest_helper'
+
+class TestKakineDirector < Minitest::Test
+  def test_convert_terraform
+    Kakine::Option.set_options(filename: 'test/fixtures/simple.yaml')
+
+    out = String.new
+    $stdout = StringIO.new(out)
+    begin
+      Kakine::Director.convert('terraform', nil)
+      json = JSON.parse(out)
+      assert_kind_of Hash, json['resource']['openstack_networking_secgroup_v2']
+      assert_equal 1, json['resource']['openstack_networking_secgroup_v2'].size
+      assert_kind_of Hash, json['resource']['openstack_networking_secgroup_rule_v2']
+      assert_equal 2, json['resource']['openstack_networking_secgroup_rule_v2'].size
+    ensure
+      $stdout = STDOUT
+    end
+  end
+
+  def test_convert_terraform_file
+    Kakine::Option.set_options(filename: 'test/fixtures/simple.yaml')
+
+    out = Tempfile.new('')
+    begin
+      Kakine::Director.convert('terraform', out)
+      out.rewind
+      json = JSON.parse(out.read)
+      assert_kind_of Hash, json['resource']['openstack_networking_secgroup_v2']
+      assert_equal 1, json['resource']['openstack_networking_secgroup_v2'].size
+      assert_kind_of Hash, json['resource']['openstack_networking_secgroup_rule_v2']
+      assert_equal 2, json['resource']['openstack_networking_secgroup_rule_v2'].size
+    ensure
+      out.close!
+    end
+  end
+end

--- a/test/test_kakine_exporter.rb
+++ b/test/test_kakine_exporter.rb
@@ -1,0 +1,14 @@
+require 'minitest_helper'
+require 'support/test_helper'
+
+class TestKakineExporter < Minitest::Test
+  def test_get_terraform
+    assert_equal Kakine::Exporter::Terraform, Kakine::Exporter.get(:terraform)
+  end
+
+  def test_get_unknown
+    assert_raises do
+      Kakine::Exporter.get(:unknown_one)
+    end
+  end
+end

--- a/test/test_kakine_exporter_terraform.rb
+++ b/test/test_kakine_exporter_terraform.rb
@@ -1,0 +1,99 @@
+require 'minitest_helper'
+require 'support/test_helper'
+
+class TestKakineExporterTerraform < Minitest::Test
+  def setup
+    tenant = 'my-tenant'
+    @sgs = [
+      Kakine::SecurityGroup.new(
+        tenant,
+        [
+          'default',
+          'description' => 'Allow internal communication',
+          'rules' => [
+            {
+              'direction' => 'ingress',
+              'ethertype' => 'IPv4',
+              'port_range_max' => nil,
+              'port_range_min' => nil,
+              'protocol' => nil,
+              'remote_group' => 'default',
+            },
+          ],
+        ],
+      ),
+      Kakine::SecurityGroup.new(
+        tenant,
+        [
+          'www',
+          'description' => 'Allow HTTP/HTTPS',
+          'rules' => [
+            {
+              'direction' => 'ingress',
+              'ethertype' => 'IPv4',
+              'port_range_max' => 80,
+              'port_range_min' => 80,
+              'protocol' => 'tcp',
+              'remote_ip_prefix' => '192.0.2.0/24',
+            },
+            {
+              'direction' => 'ingress',
+              'ethertype' => 'IPv4',
+              'port_range_max' => 443,
+              'port_range_min' => 443,
+              'protocol' => 'tcp',
+              'remote_ip_prefix' => '192.0.2.0/24',
+            },
+          ],
+        ],
+      ),
+    ]
+  end
+
+  def test_export
+    out = String.new
+    exporter = Kakine::Exporter::Terraform.new(StringIO.new(out, 'w'))
+    exporter.export(@sgs)
+
+    expected = {
+      'resource' => {
+        'openstack_networking_secgroup_v2' => {
+          'default' => {
+            'name' => 'default',
+            'description' => 'Allow internal communication'
+          },
+          'www' => {
+            'name' => 'www',
+            'description' => 'Allow HTTP/HTTPS'
+          }
+        },
+        'openstack_networking_secgroup_rule_v2' => {
+          'default-ingress_IPv4_default' => {
+            'direction' => 'ingress',
+            'ethertype' => 'IPv4',
+            'remote_group_id' => '${openstack_networking_secgroup_v2.default.id}',
+            'security_group_id' => '${openstack_networking_secgroup_v2.default.id}'
+          },
+          'www-ingress_IPv4_tcp_80_80' => {
+            'direction' => 'ingress',
+            'ethertype' => 'IPv4',
+            'protocol' => 'tcp',
+            'port_range_min' => 80,
+            'port_range_max' => 80,
+            'security_group_id' => '${openstack_networking_secgroup_v2.www.id}'
+          },
+          'www-ingress_IPv4_tcp_443_443' => {
+            'direction' => 'ingress',
+            'ethertype' => 'IPv4',
+            'protocol' => 'tcp',
+            'port_range_min' => 443,
+            'port_range_max' => 443,
+            'security_group_id' => '${openstack_networking_secgroup_v2.www.id}'
+          }
+        }
+      }
+    }
+
+    assert_equal expected, JSON.parse(out)
+  end
+end


### PR DESCRIPTION
I find it useful if kakine can generate Terraform configuration from SG definitions written in YAML.

----

from
```
www:
  rules:
  - direction: ingress
    protocol: tcp
    ethertype: IPv4
    port: [80, 443]
    remote_ip:
      - 192.168.0.0/16
      - 172.16.0.0/12
  description: Allow HTTP and HTTPS
```
to
```
{
  "resource": {
    "openstack_networking_secgroup_v2": {
      "www": {
        "name": "www",
        "description": "Allow HTTP and HTTPS"
      }
    },
    "openstack_networking_secgroup_rule_v2": {
      "www-ingress_IPv4_tcp_80_80_192_168_0_0_16": {
        "direction": "ingress",
        "ethertype": "IPv4",
        "protocol": "tcp",
        "port_range_min": 80,
        "port_range_max": 80,
        "remote_ip_prefix": "192.168.0.0/16",
        "security_group_id": "${openstack_networking_secgroup_v2.www.id}"
      },
      "www-ingress_IPv4_tcp_443_443_192_168_0_0_16": {
        "direction": "ingress",
        "ethertype": "IPv4",
        "protocol": "tcp",
        "port_range_min": 443,
        "port_range_max": 443,
        "remote_ip_prefix": "192.168.0.0/16",
        "security_group_id": "${openstack_networking_secgroup_v2.www.id}"
      },
      "www-ingress_IPv4_tcp_80_80_172_16_0_0_12": {
        "direction": "ingress",
        "ethertype": "IPv4",
        "protocol": "tcp",
        "port_range_min": 80,
        "port_range_max": 80,
        "remote_ip_prefix": "172.16.0.0/12",
        "security_group_id": "${openstack_networking_secgroup_v2.www.id}"
      },
      "www-ingress_IPv4_tcp_443_443_172_16_0_0_12": {
        "direction": "ingress",
        "ethertype": "IPv4",
        "protocol": "tcp",
        "port_range_min": 443,
        "port_range_max": 443,
        "remote_ip_prefix": "172.16.0.0/12",
        "security_group_id": "${openstack_networking_secgroup_v2.www.id}"
      }
    }
  }
}
```