### PR TITLE
Allow specifying port range with N-M notation

### DIFF
--- a/test/fixtures/yaml/rule_expansion.yaml
+++ b/test/fixtures/yaml/rule_expansion.yaml
@@ -58,3 +58,12 @@ sg_protocol:
     port: 53
     remote_ip: 0.0.0.0/0
   description: expansion by protocol
+
+sg_port_range:
+  rules:
+    - direction: ingress
+      protocol: tcp
+      ethertype: IPv4
+      port: [20-21, 22]
+      remote_ip: 0.0.0.0/0
+  description: expansion by port with range notation

--- a/test/test_kakine_yaml.rb
+++ b/test/test_kakine_yaml.rb
@@ -24,6 +24,15 @@ class TestKakineYaml < Minitest::Test
     assert_equal 2, yaml['sg_protocol']['rules'].count
   end
 
+  def test_rule_expansion
+    yaml = Kakine::Resource::Yaml.load_file('test/fixtures/yaml/rule_expansion.yaml')
+
+    assert_equal 2, yaml['sg_port_range']['rules'].count
+    assert_equal 20, yaml['sg_port_range']['rules'][0]['port_range_min']
+    assert_equal 21, yaml['sg_port_range']['rules'][0]['port_range_max']
+    assert_equal 22, yaml['sg_port_range']['rules'][1]['port']
+  end
+
   def test_expand_rules
     # empty input
     assert_equal [], Kakine::Resource::Yaml.expand_rules([], 'key')


### PR DESCRIPTION
Adds shorthand syntax for port range specification,
`port: 40-50` interpreted as `{ port_range_min: 40, port_range_max: 50 }`

This is useful in combination with rule expansion, e.g.
```yaml
rules:
  - port: [20-21, 80, 443]  # ftp & https?
    ...
```