### PR TITLE
Ignore description for default SG

### DIFF
--- a/lib/kakine/builder.rb
+++ b/lib/kakine/builder.rb
@@ -1,5 +1,5 @@
 module Kakine
-  class Builder 
+  class Builder
     class << self
       def create_security_group(sg)
         attributes = { name: sg.name, description: sg.description, tenant_id: sg.tenant_id }
@@ -26,7 +26,7 @@ module Kakine
       end
 
       def convergence_security_group(new_sg, current_sg)
-        if new_sg.description != current_sg.description
+        if new_sg.name != 'default' && new_sg.description != current_sg.description
           delete_security_group(current_sg)
           first_create_security_group(new_sg)
         else
@@ -34,11 +34,11 @@ module Kakine
           first_create_rule(new_sg, current_sg)
         end
       end
-      
+
       def already_setup_security_group(new_sg, current_sgs)
         current_sgs.find { |current_sg| current_sg.name == new_sg.name }
       end
-      
+
       def create_security_rule(tenant_name, sg_name, rule)
         sg = Kakine::Resource.get(:openstack).security_group(tenant_name, sg_name)
         security_group_id =  Kakine::Option.dryrun? && sg.nil? ? Kakine::Adapter.instance.id(sg_name) : sg.id
@@ -58,7 +58,7 @@ module Kakine
           delete_security_rule(tenant_name, sg_name, rule)
         end if target_sg
       end
-      
+
       def first_create_rule(new_sg, current_sg)
         new_sg.rules.map do |rule|
           unless current_sg.find_by_rule(rule)
@@ -81,12 +81,12 @@ module Kakine
       def delete_id_column(sgs)
         case sgs
         when Array
-          sgs.map { |sg| delete_id_column(sg) } 
+          sgs.map { |sg| delete_id_column(sg) }
         when Hash
           sgs.inject({}) do |hash, (k, v)|
-            hash[k] = delete_id_column(v) if k != "id" 
+            hash[k] = delete_id_column(v) if k != "id"
             hash
-          end 
+          end
         else
           sgs
         end

--- a/lib/kakine/resource/yaml.rb
+++ b/lib/kakine/resource/yaml.rb
@@ -34,7 +34,7 @@ module Kakine
             raise(Kakine::ConfigureError, "#{sg_name}:rules and description is required")
           when !sg[1].key?("rules")
             raise(Kakine::ConfigureError, "#{sg_name}:rules is required")
-          when !sg[1].key?("description")
+          when sg_name != 'default' && !sg[1].key?("description")
             raise(Kakine::ConfigureError, "#{sg_name}:description is required")
           end
         end

--- a/test/support/test_helper.rb
+++ b/test/support/test_helper.rb
@@ -2,18 +2,34 @@ module Kakine
   module TestHelper
     class << self
 
+      def default_security_group_with_description(description = 'default')
+        [
+          "default",
+          {
+            "rules" => [
+            ],
+            "description" => description,
+            "id"          => "test_id_3",
+          }
+        ]
+      end
+
       def full_rule_security_group
         full_security_group(full_rule_port_remote_ip, "test_full_group")
       end
 
-      def full_security_group(rule, name)
+      def full_rule_security_group_with_description(description)
+        full_security_group(full_rule_port_remote_ip, "test_full_group", description)
+      end
+
+      def full_security_group(rule, name, description = 'test_description')
         [
           name,
           {
             "rules" => [
               rule
             ],
-            "description" => "test_description",
+            "description" => description,
             "id"          => "test_id_1"
           }
         ]

--- a/test/test_kakine_builder.rb
+++ b/test/test_kakine_builder.rb
@@ -55,6 +55,26 @@ class TestKakineBuilder < Minitest::Test
     assert_equal(Kakine::Builder.convergence_security_group(icmp_sg, current_sg), ["Create Rule: icmp_group"])
   end
 
+  def test_convergence_security_group_change_description
+    current_sg = Kakine::SecurityGroup.new("test_tenant", Kakine::TestHelper.full_rule_security_group_with_description("description_2"))
+    new_sg = Kakine::SecurityGroup.new("test_tenant", Kakine::TestHelper.full_rule_security_group_with_description("description_1"))
+
+    Kakine::Builder.expects(:delete_security_group).with(current_sg)
+    Kakine::Builder.expects(:create_security_group).with(new_sg)
+
+    Kakine::Builder.convergence_security_group(new_sg, current_sg)
+  end
+
+  def test_convergence_security_group_change_description_default
+    current_sg = Kakine::SecurityGroup.new("test_tenant", Kakine::TestHelper.default_security_group_with_description("description_2"))
+    new_sg = Kakine::SecurityGroup.new("test_tenant", Kakine::TestHelper.default_security_group_with_description("description_1"))
+
+    Kakine::Builder.expects(:delete_security_group).never
+    Kakine::Builder.expects(:create_security_group).never
+
+    Kakine::Builder.convergence_security_group(new_sg, current_sg)
+  end
+
   def test_already_setup_security_group
     current_sgs = []
     current_sgs << Kakine::SecurityGroup.new("test_tenant", Kakine::TestHelper.full_rule_security_group)

--- a/test/test_kakine_yaml.rb
+++ b/test/test_kakine_yaml.rb
@@ -1,6 +1,28 @@
 require 'minitest_helper'
 
 class TestKakineYaml < Minitest::Test
+  def test_validate_decription_existance
+    data = {
+      'http' => {
+        'rules' => [],
+      }
+    }
+
+    assert_raises Kakine::ConfigureError do
+      Kakine::Resource::Yaml.validate_file_input(data)
+    end
+  end
+
+  def test_validate_decription_existance_default
+    data = {
+      'default' => {
+        'rules' => [],
+      }
+    }
+
+    Kakine::Resource::Yaml.validate_file_input(data)
+  end
+
   def test_meta_section
     yaml = Kakine::Resource::Yaml.load_file('test/fixtures/yaml/meta_section.yaml')
 


### PR DESCRIPTION
Description for the default security group is hard-coded in OpenStack Neutron and cannot be specified on creation (and cannot be updated as non-default SGs).
This patch changes the builder to ignore the description for the default SG in application, in order not to destroy and recreate the default SG when the hard-coded one does not match the description in YAML configuration.